### PR TITLE
Update the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 ```julia
 julia> using GitRepl
 
-julia> gitrepl() # you only need to run this once per Julia session
-
 # Press , to enter the Git REPL mode
 
 git> clone https://github.com/JuliaRegistries/General

--- a/src/GitRepl.jl
+++ b/src/GitRepl.jl
@@ -18,6 +18,7 @@ function _gitrepl_parser(repl_input::AbstractString)
 end
 
 """
+    gitrepl()
     gitrepl(; kwargs...)
 
 Set up the Git REPL mode.


### PR DESCRIPTION
We now automatically initialize the Git REPL mode when you do `import GitRepl` or `using GitRepl`.